### PR TITLE
Tests not working when invoked by npm

### DIFF
--- a/test/octicons.font.js
+++ b/test/octicons.font.js
@@ -2,7 +2,7 @@ var glob = require("glob").sync;
 
 module.exports = {
     fontName: "Octicons",
-    files: glob("./octicons/svg/*.svg"),
+    files: glob("./octicons/svg/*.svg", {cwd: __dirname}),
     baseClass: "octicon",
     classPrefix: "octicon-",
     cssFile: 'css'


### PR DESCRIPTION
When I run tests with `npm run test` they fail. See the log below:

```console
semenov@daedra ~/tmp $ git clone https://github.com/pankajpatel/fontgen-loader
semenov@daedra ~/tmp $ cd fontgen-loader/
semenov@daedra ~/tmp/fontgen-loader (master) $ npm i -D
...
semenov@daedra ~/tmp/fontgen-loader (master) $ npm run test

> font-gen-loader@0.2.5 test /Users/semenov/tmp/fontgen-loader
> webpack --config=test/webpack.config.js

Hash: a679e1e0203f689577e3
Version: webpack 1.14.0
Time: 1502ms
                                              Asset     Size  Chunks             Chunk Names
      370c3f7255fa5d419c8765dd37725a78-octicon2.eot  1.99 kB          [emitted]
     4145d6a6bf2c3f9f9e1de1c692e8aa9b-octicon2.woff  1.19 kB          [emitted]
      36920de3ec4d5a0633219632f5448c4e-octicon2.ttf  1.82 kB          [emitted]
      3676f656950bf4376cacff3090b58f59-octicon2.svg  1.51 kB          [emitted]
 843996aee0f9a281a7b8bdfc8d8f8787-Octicons-json.eot  35.1 kB          [emitted]
1c3ec64a832c1e9722b002673946b84c-Octicons-json.woff    20 kB          [emitted]
 722d64b9a9825367a215c663810a0e97-Octicons-json.ttf  34.9 kB          [emitted]
 3b79ac2ed624c7b404642508057209d9-Octicons-json.svg   160 kB          [emitted]
                                  Octicons-json.css  10.2 kB          [emitted]
                                          bundle.js    26 kB       0  [emitted]  main
   [0] ./entry.js 685 bytes {0} [built]
    + 8 hidden modules

ERROR in ../~/css-loader!..!./octicons.font.js
Module build failed: Error: "options.files" is empty.
    at webfont (/Users/semenov/tmp/fontgen-loader/node_modules/webfonts-generator/src/index.js:53:41)
    at Object.module.exports (/Users/semenov/tmp/fontgen-loader/index.js:160:5)
 @ ./octicons.font.js 4:14-97
```

After the fix:

```console
semenov@daedra ~/tmp/fontgen-loader (master) $ npm run test

> font-gen-loader@0.2.5 test /Users/semenov/tmp/fontgen-loader
> webpack --config=test/webpack.config.js

Hash: c3daf0394d845b8aaf4b
Version: webpack 1.14.0
Time: 1959ms
                                              Asset     Size  Chunks             Chunk Names
      0a336215097cd753d22e74e2a696e1e1-octicon2.ttf  1.82 kB          [emitted]
      6a26ebee3fbe7634e2dca8271e17e78b-Octicons.eot    35 kB          [emitted]
      1e725e351bcde755d89e47ee70e89dfc-Octicons.ttf  34.8 kB          [emitted]
      6e83cb3b29b9645610afaa082040c967-Octicons.svg   160 kB          [emitted]
                                   css/Octicons.css   9.3 kB          [emitted]
      7cbe91a4bd4c9c1ec1d222d2ed74fd89-octicon2.eot  1.99 kB          [emitted]
     2a65c041b1e79f56df6ed4b52d03c618-octicon2.woff  1.19 kB          [emitted]
     9e8d874233377804bbc936fa04f06afe-Octicons.woff    20 kB          [emitted]
      3676f656950bf4376cacff3090b58f59-octicon2.svg  1.51 kB          [emitted]
 6f068b01f0093d20c33d87db5d91ccdc-Octicons-json.eot  35.1 kB          [emitted]
b606f36d04762628c3e7252f19f6373d-Octicons-json.woff    20 kB          [emitted]
 123a327836510c4330842e6bbde6adb9-Octicons-json.ttf  34.9 kB          [emitted]
 3b79ac2ed624c7b404642508057209d9-Octicons-json.svg   160 kB          [emitted]
                                  Octicons-json.css  10.2 kB          [emitted]
                                          bundle.js  36.6 kB       0  [emitted]  main
   [0] ./entry.js 685 bytes {0} [built]
    + 8 hidden modules
```