### PR TITLE
Fixed baseSelector usage and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ module.exports = {
         ],
     "fontName": "Awesomecons",
     "classPrefix": "ai-",
-    "baseSelector": "ai",
+    "baseSelector": ".ai",
     "fixedWidth": true,
     "types": ["eot", "woff", "ttf", "svg"] // this is the default
 }
@@ -102,13 +102,15 @@ An array of SVG icon files. Supports glob
 Name of your font.
 
 - `classPrefix`, String
+Default: `icon-`
 The prefix to be used with each icon class.
 
 - `baseSelector`, String
-The base class, under which each icon class is to be crated.
+Default: `.icon`
+The base CSS selector, under which each icon class is to be crated.
 
 - `types`, Array
-Possible values are: `["svg", "eot", "wof", "ttf"]`.
+Possible values are: `["svg", "eot", "woff", "woff2", "ttf"]`.
 
 - `cssTemplate`, String
 Which template to use? By default, a CSS one is used. The template is to be processed by Handlebars. See [the generator](https://github.com/sunflowerdeath/webfonts-generator)'s readme itself for more info.

--- a/index.js
+++ b/index.js
@@ -90,6 +90,15 @@ module.exports = function (content) {
         formats = [formats];
     }
 
+    // Populate templateOptions with only what's been specifically passed.
+    // Otherwise rely on upstream defaults.
+    var templateOptions = {};
+    ['baseClass', 'baseSelector', 'classPrefix'].forEach(function(f) {
+        if (f in config) {
+            templateOptions[f] = config[f];
+        }
+    });
+
     var fontconf = {
         files: config.files,
         fontName: config.fontName,
@@ -97,10 +106,7 @@ module.exports = function (content) {
         order: formats,
         fontHeight: config.fontHeight || 1000, // Fixes conversion issues with small svgs
         codepoints: config.codepoints,
-        templateOptions: {
-            baseSelector: config.baseClass || "icon",
-            classPrefix: "classPrefix" in config ? config.classPrefix : "icon-"
-        },
+        templateOptions: templateOptions,
         dest: "",
         writeFiles: false,
         formatOptions: config.formatOptions || {}

--- a/test/octicons-json.font.json
+++ b/test/octicons-json.font.json
@@ -3,7 +3,7 @@
     "files" : [
         "./octicons/svg/*.svg"
     ],
-    "baseSelector" : "octicon-json",
+    "baseSelector" : ".octicon-json",
     "classPrefix" : "octicon-json-",
     "cssFile": true
 }

--- a/test/octicons.font.js
+++ b/test/octicons.font.js
@@ -3,7 +3,7 @@ var glob = require("glob").sync;
 module.exports = {
     fontName: "Octicons",
     files: glob("./octicons/svg/*.svg", {cwd: __dirname}),
-    baseSelector: "octicon",
+    baseSelector: ".octicon",
     classPrefix: "octicon-",
     cssFile: 'css'
 };


### PR DESCRIPTION
Unfortunately in #3 I didn't pay much attention to the deprecation of `baseClass` in favour of `baseSelector` in [webfonts-generator](https://github.com/sunflowerdeath/webfonts-generator/commit/6905aa075c40341d12a68f786ef77fd606a4b784) and almost blindly replaced its usages (and even missed one of them). As the result, the following invalid CSS was generated:

```css
icon {
        line-height: 1;
}

icon:before {
        font-family: Octicons-json !important;
        font-style: normal;
        font-weight: normal !important;
        vertical-align: top;
}

.octicon-json-alert:before {
        content: "\f101";
}
```

This PR fixes the problem, updates tests and documentation. It also adds backward compatibility with old configs that still use `baseClass`.